### PR TITLE
General fixes

### DIFF
--- a/_includes/paginator-links.html
+++ b/_includes/paginator-links.html
@@ -12,15 +12,30 @@
   {% if paginator.page <= halfPages %}
     <!-- left-align -->
     {% assign start = 1 %}
-    {% assign end = maxPages | append: ',' | append: paginator.total_pages | split: ',' | sort | first | plus: 0 %}
+    {% if paginator.total_pages > maxPages %}
+        {% assign end = maxPages %}
+    {% else %}
+        {% assign end = paginator.total_pages %}
+    {% endif %}
   {% elsif right-margin <= halfPages %}
     <!-- right-align -->
     {% assign start = paginator.total_pages | minus: maxPages | plus: 1 | append: ',' | append: 1 | split: ',' | sort | last | plus: 0 %}
     {% assign end = paginator.total_pages %}
   {% else %}
     <!-- center-align -->
-    {% assign start = paginator.page | minus: halfPages | append: ',' | append: 1 | split: ',' | sort | last | plus: 0 %}
-    {% assign end = paginator.page | plus: halfPages | append: ',' | append: paginator.total_pages | split: ',' | sort | first | plus: 0 %}
+    {% assign position-less-half = paginator.page | minus: halfPages %}
+    {% if position-less-half < 1 %}
+        {% assign start = 1 %}
+    {% else %}
+        {% assign start = position-less-half %}
+    {% endif %}
+
+    {% assign position-plus-half = paginator.page | plus: halfPages %}
+    {% if position-plus-half > paginator.total_pages %}
+        {% assign end = paginator.total_pages %}
+    {% else %}
+        {% assign end = position-plus-half %}
+    {% endif %}
   {% endif %}
 
   <!-- First page -->

--- a/_includes/paginator-links.html
+++ b/_includes/paginator-links.html
@@ -7,6 +7,7 @@
     {% assign maxPages = 5 %}
   {% endif %}
 
+  {% assign halfPages = maxPages | divided_by: 2 %}
   {% assign right-margin = paginator.total_pages | minus: paginator.page %}
   {% if paginator.page <= halfPages %}
     <!-- left-align -->
@@ -18,7 +19,6 @@
     {% assign end = paginator.total_pages %}
   {% else %}
     <!-- center-align -->
-    {% assign halfPages = maxPages | divided_by: 2 %}
     {% assign start = paginator.page | minus: halfPages | append: ',' | append: 1 | split: ',' | sort | last | plus: 0 %}
     {% assign end = paginator.page | plus: halfPages | append: ',' | append: paginator.total_pages | split: ',' | sort | first | plus: 0 %}
   {% endif %}


### PR DESCRIPTION
Hey, I came across a few issues when I incorporated your work into a theme of mine. Namely:
- The `halfPages` variable was being checked before it was assigned. This meant center alignment was executed regardless of what page the user was on.
- Calculation of minimum / maximum values failed in cases where there were 10 or more pages. This was due to the `sort` filter working on strings, not numbers. For example, presented with an array `[9,10]`, the filter would return `[10,9]`, thus upsetting the calculation used to solve the minimum of the two.

Here's some proposed fixes. I'm afraid they don't win points for style but they get the job done. Many thanks for the original work — it was a great help in writing a more flexible pagination widget for Jekyll (I still can't believe Liquid lacks a damned `min`/`max` filter)
